### PR TITLE
Address CI failures

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -21,9 +21,10 @@ jobs:
         - ubuntu-latest
         python-version:
         - "3.11"  # Earliest supported version
-        - "3.12"  # Latest supported version
+        - "3.12"
+        - "3.13"  # Latest supported version
         # commented: only enable once next Python version enters RC
-        # - "3.13.0-rc.1"  # Development version
+        # - "3.14.0-rc.1"  # Development version
 
       fail-fast: false
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -57,7 +57,7 @@ jobs:
         SDMX_TEST_DATA: ./sdmx-test-data/
       run: |
         pytest dsss \
-          -ra --color=yes --verbose \
+          -rA --color=yes --durations=20 --verbose \
           --cov-report=xml \
           --numprocesses auto
       shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.11.1
+  rev: v1.12.0
   hooks:
   - id: mypy
     additional_dependencies:
@@ -11,7 +11,7 @@ repos:
     - starlette
     args: []
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.7
+  rev: v0.6.9
   hooks:
   - id: ruff
   - id: ruff-format

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -1,8 +1,10 @@
 What's new?
 ***********
 
-.. Next release
-.. ============
+Next release
+============
+
+- Python 3.13 (`released 2024-10-07 <https://www.python.org/downloads/release/python-3130/>`_) is fully supported (:pull:`13`).
 
 v1.1.0 (2024-09-04)
 ===================

--- a/dsss/common.py
+++ b/dsss/common.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import datetime
+from traceback import format_exception
 from typing import TYPE_CHECKING, Collection, List, Mapping, Optional, Type
 
 import sdmx
@@ -65,7 +66,13 @@ class SDMXResponse(Response):
                 body = sdmx.to_xml(self.message, pretty_print=True)
             except Exception as e:
                 body = sdmx.to_xml(
-                    gen_error_message(500, f"Error rendering message: {e!r}"),
+                    gen_error_message(
+                        500,
+                        "".join(
+                            ["Error rendering message:\n", f"{self.message!r}\n"]
+                            + format_exception(e)
+                        ),
+                    ),
                     pretty_print=True,
                 )
         else:

--- a/dsss/starlette.py
+++ b/dsss/starlette.py
@@ -11,6 +11,7 @@
 
 from datetime import datetime
 from importlib import import_module
+from traceback import format_exception
 from typing import TYPE_CHECKING
 
 from starlette.applications import Starlette
@@ -89,7 +90,7 @@ def build_app(**config_kwargs):
 async def handle_exception(request: "starlette.requests.Request", exc):
     """Handle errors."""
     code = exc.status_code
-    text = repr(exc)
+    text = "\n\n".join([repr(exc)] + format_exception(exc))
 
     if code == 404:
         # 404 indicates a routing failure, e.g. the user gave a malformed URL

--- a/dsss/testing.py
+++ b/dsss/testing.py
@@ -28,7 +28,9 @@ def ignore(p: "Path") -> bool:
     references a different DSD (DataStructure=ECB:EXR(1.0)) than the real-world one
     (DataStructure=ECB:ECB_EXR1(1.0)). Ignore this data flow definition.
     """
-    return p.parts[-3:] == ("v3", "xml", "dataflow.xml")
+    return (p.parts[-3:] == ("v3", "xml", "dataflow.xml")) or (
+        p.parts[-2:] == ("IAEG-SDGs", "metadatastructure-0.xml")
+    )
 
 
 @pytest.fixture(scope="session")

--- a/dsss/tests/test_core.py
+++ b/dsss/tests/test_core.py
@@ -196,11 +196,16 @@ def test_structure_all(
     # Response can be parsed as SDMX-ML
     msg = sdmx.read_sdmx(BytesIO(rv.content))
 
-    if count is None:
-        # An error message was returned indicating the given endpoint is not implemented
-        assert isinstance(msg, ErrorMessage)
-    else:
+    if isinstance(msg, ErrorMessage):
+        if count is None:
+            pass  # No returned objects, because the given endpoint is not implemented
+        else:
+            print(rv.content.decode())
+            assert False, "Unexpected ErrorMessage"
+    elif count is not None:
         assert_le(count, len(msg.objects(klass)))
+    else:  # pragma: no cover
+        raise Exception("Malformed test case")
 
 
 @pytest.mark.parametrize(

--- a/dsss/tests/test_store.py
+++ b/dsss/tests/test_store.py
@@ -15,7 +15,7 @@ from dsss.store import (
     StructuredFileStore,
     UnionStore,
 )
-from dsss.testing import GHA, assert_le
+from dsss.testing import assert_le
 
 if TYPE_CHECKING:
     import pathlib
@@ -293,7 +293,7 @@ class TestStore:
         )
 
         # Number of dimensions in the object prior to resolving the reference
-        if isinstance(s, (DictStore, UnionStore)) and not GHA:
+        if isinstance(s, (DictStore, UnionStore)):
             # With DictStore or UnionStore dispatching to DictStore, objects all remain
             # in memory and refer to one another; is_external_reference is False
             N_dimensions_pre, is_external_reference_pre = 4, False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Recent runs of the "pytest" CI workflow have failed with:

```
FAILED dsss/tests/test_core.py::test_structure_all[categorisation-7-URL0] - AttributeError: 'ErrorMessage' object has no attribute 'objects'
FAILED dsss/tests/test_core.py::test_structure_all[categorisation-7-URL1] - AttributeError: 'ErrorMessage' object has no attribute 'objects'
FAILED dsss/tests/test_core.py::test_structure_all[metadatastructure-5-URL0] - AttributeError: 'ErrorMessage' object has no attribute 'objects'
FAILED dsss/tests/test_core.py::test_structure_all[metadatastructure-5-URL1] - AttributeError: 'ErrorMessage' object has no attribute 'objects'
```
These don't occur on my local system; only on GitHub Actions.

Addressed by:
- Show the contents of these unexpected ErrorMessages.
- Improve `.testing.ignore()` to exclude other XML files containing SDMX-ML 3.0 artefacts. The apparent cause of the failures is that the structure query would retrieve these objects and try to write them to an SDMX-ML 2.1 StructureMessage, and fail because this is not supported. The same structures are defined in SDMX-ML 2.1 elsewhere in the test specimen collection, and it seems these are read in a different order on GHA vs. locally.

Other changes:
- Test and advertise Python 3.13 support.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A
- [x] Update doc/whatsnew.rst
