### PR TITLE
Adjust for sdmx1 v2.21

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 name: Build package / publish
 
 on:
-  pull_request:  # Check that package can be built even on PRs
+  pull_request:
     branches: [ main ]
   push:
     branches: [ main ]
@@ -13,8 +13,35 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  python-version: "3.13"
+  # Uncomment for testing
+  # UV_PUBLISH_URL: https://test.pypi.org/legacy/
+
 jobs:
   publish:
-    uses: iiasa/actions/.github/workflows/publish.yaml@main
-    secrets:
-      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+    environment:
+      name: publish
+
+    permissions:
+      id-token: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/setup-uv@v5
+      with:
+        cache-dependency-glob: "**/pyproject.toml"
+        python-version: ${{ env.python-version }}
+
+    - name: Build
+      run: uv build
+
+    - name: Publish
+      if: >-
+        github.event_name == 'release' || (
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags')
+        )
+      run: uv publish --trusted-publishing=always

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,36 +37,27 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Check out test data
-      uses: actions/checkout@v4
+    - name: Set up uv, Python
+      uses: astral-sh/setup-uv@v5
       with:
-        repository: khaeru/sdmx-test-data
-        path: sdmx-test-data
-
-    - uses: astral-sh/setup-uv@v4
-      with:
-        enable-cache: true
         cache-dependency-glob: "**/pyproject.toml"
+        python-version: ${{ matrix.python-version }}
 
-    - name: Install
-      run: |
-        uv venv --python=${{ matrix.python-version }}
-        uv pip install .[tests]
+    - name: Install the package and dependencies
+      run: uv pip install .[tests]
 
     - name: Run pytest
-      env:
-        SDMX_TEST_DATA: ./sdmx-test-data/
       run: |
         uv run --no-sync \
           pytest dsss \
           -rA --color=yes --durations=20 --verbose \
+          --sdmx-fetch-data \
           --cov-report=xml \
           --numprocesses auto
       shell: bash
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v4
-      with: { token: "${{ secrets.CODECOV_TOKEN }}" }
+      uses: codecov/codecov-action@v5
 
   pre-commit:
     name: Code quality
@@ -75,10 +66,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v4
+    - uses: astral-sh/setup-uv@v5
       with:
-        enable-cache: true
         cache-dependency-glob: "**/pyproject.toml"
+        python-version: "3.13"
     - uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit
@@ -86,4 +77,4 @@ jobs:
         lookup-only: ${{ github.event_name == 'schedule' }}
         # lookup-only: true
     - name: Run pre-commit
-      run: uvx --python=3.13 pre-commit run --all-files --show-diff-on-failure --color=always
+      run: uvx pre-commit run --all-files --color=always --show-diff-on-failure --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.12.0
+  rev: v1.14.1
   hooks:
   - id: mypy
+    pass_filenames: false
     additional_dependencies:
     - GitPython
     - lxml-stubs
     - pytest
     - sdmx1
     - starlette
-    args: []
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.9
+  rev: v0.9.1
   hooks:
   - id: ruff
   - id: ruff-format

--- a/dsss/tests/test_core.py
+++ b/dsss/tests/test_core.py
@@ -166,7 +166,7 @@ def test_structure(client, source, url, count):
         pytest.param(
             "availableconstraint", None, marks=pytest.mark.xfail(raises=ValueError)
         ),
-        ("categorisation", 5),
+        ("categorisation", 6),
         ("categoryscheme", 3),
         ("codelist", 85),
         ("conceptscheme", 23),  # NB 23 on GHA; 25 locally

--- a/dsss/tests/test_testing.py
+++ b/dsss/tests/test_testing.py
@@ -40,4 +40,4 @@ def test_cached_store_for_app1(cached_store_for_app):
     result = s.list(klass=v21.DataflowDefinition, maintainer="ECB", id="EXR")
     assert len(result)
 
-    assert 5 == len(s.list(klass=common.Categorisation))
+    assert 6 == len(s.list(klass=common.Categorisation))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["build", "setuptools-scm"]
+requires = ["hatchling", "versioningit"]
+build-backend = "hatchling.build"
 
 [project]
 dynamic = ["version"]
@@ -57,6 +58,9 @@ exclude_also = [
 ]
 omit = ["dsss/storage/google_cloud_storage.py"]
 
+[tool.hatch]
+version.source = "versioningit"
+
 [tool.mypy]
 exclude = ["^build/"]
 
@@ -74,7 +78,5 @@ addopts = "--cov=dsss --cov-report="
 select = ["C9", "E", "F", "I", "W"]
 mccabe.max-complexity = 10
 
-[tool.setuptools.packages]
-find = {}
-
-[tool.setuptools_scm]
+[tool.versioningit]
+default-version = "0.1.dev1"  # Match setuptools-scm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ omit = ["dsss/storage/google_cloud_storage.py"]
 version.source = "versioningit"
 
 [tool.mypy]
-exclude = ["^build/"]
+files = ["conftest.py", "doc", "dsss"]
 
 [[tool.mypy.overrides]]
 # Packages for which no type hints are available

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ tests = [
   "dsss[git-store]",
   "pytest >= 8",
   "pytest-cov",
-  "sdmx1[tests]",  # for Jinja2
+  "sdmx1[tests] >= 2.21.1",  # for Jinja2; version for --sdmx-fetch-data
   "starlette[full]",  # for httpx
 ]
 


### PR DESCRIPTION
- With sdmx1, a greater number of Categorisation specimens can be handled.

Housekeeping:
- Use a first-party "publish" workflow with `uv publish` and PyPI/GitHub trusted publishing.

### PR checklist
- [x] Checks all ✅
- ~Update documentation~ N/A; test suite changes only
- ~Update doc/whatsnew.rst~
